### PR TITLE
Add support to Meteor 3.0-alpha

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
-  name: 'fredericomaia:easy-schema',
-  version: '1.1.1',
+  name: 'jam:easy-schema',
+  version: '1.1.0-alpha.300.19',
   summary: 'An easy way to add schema validation for Meteor apps',
   git: 'https://github.com/fredmaiaarantes/easy-schema',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'jam:easy-schema',
   version: '1.1.0-alpha.300.19',
   summary: 'An easy way to add schema validation for Meteor apps',
-  git: 'https://github.com/fredmaiaarantes/easy-schema',
+  git: 'https://github.com/jamauro/easy-schema',
   documentation: 'README.md'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'jam:easy-schema',
-  version: '1.1.0',
+  name: 'fredericomaia:easy-schema',
+  version: '1.1.1',
   summary: 'An easy way to add schema validation for Meteor apps',
-  git: 'https://github.com/jamauro/easy-schema',
+  git: 'https://github.com/fredmaiaarantes/easy-schema',
   documentation: 'README.md'
 });
 
@@ -11,7 +11,7 @@ Npm.depends({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('2.8.1');
+  api.versionsFrom(['2.8.1', '3.0-alpha.19']);
   api.use('mongo');
   api.use('check');
   api.use('ecmascript');


### PR DESCRIPTION
Add `3.0-alpha.19` to `api.versionsFrom()` to support Meteor 3.0-alpha.