### PR TITLE
Improve TS Type Inference by extending Meteor Check Types

### DIFF
--- a/lib/attach/client.js
+++ b/lib/attach/client.js
@@ -10,5 +10,5 @@ import { shape } from '../shape.js';
 Mongo.Collection.prototype.attachSchema = function(schema) {
   /** @type {import('meteor/check').Match.Pattern} */
   this.schema = { ...shape({...schema, ...config.base}), '$id': `/${this._name}` };
-  return;
+  return this;
 };

--- a/lib/attach/server.js
+++ b/lib/attach/server.js
@@ -177,7 +177,7 @@ Mongo.Collection.prototype.attachSchema = function(schema) {
 
     attachMongoSchema(collection, fullSchema);
 
-    return;
+    return this;
   } catch (error) {
     console.error(error)
   }


### PR DESCRIPTION
Relates to #7 

Note:

I've run into some hiccups trying to figure out testing.

When I ran `meteor test-packages ./` I got 157/173 tests passing with a `defaults - insert - basic` failing and a bunch of other tests "waiting". New to this so not sure what I should do to get those working (if anything. e.g. maybe out of scope).

However, these changes mostly affect type inference, which I'm not sure how to test properly yet.

The two changes that affect the runtime are in `lib/attach` where I made both client and server versions of `attachSchema` return `this` to match the Collection typing trick in the .d.ts file.

Three things two consider:

1. Were types generated using the existing JS Doc types? If so, would you prefer I work from there instead of modifying the easy-schema.d.ts file? (happy to if preferred, especially given the new `@import` tag, but not sure if it'd affect declaration merging at all)
2. I can't find a good way to type Collection based on the attached schema without erasing the type of the output of `transform`.
3. Should this export an alias of `PatternMatch` that's something like Valibot's [InferOutput](https://valibot.dev/api/InferOutput/)?

My best attempt at fixing the second issue was something like:
```ts
declare module 'meteor/mongo' {
  namespace Mongo {
    interface Collection<T, U = T> {
      attachSchema<P extends Pattern, T, U>(this: Collection<T, U>, schema: P): Collection<PatternMatch<P>, T extends U ? P : U>
      schema?: Pattern;
    }
  }
}
```

which infers U correctly, but it's not that clean. So I didn't implement it for now. I think if someone really wants a typesafe `Collection<T, U>` they might need to use TypeScript and pass in something like:

```ts
import type { PatternMatch } from 'meteor/jam:easy-schema'
type MyDoc = PatternMatch<typeof MySchema>
const coll = new Mongo.Collection<MyDoc>('blah', { transform(doc) { .... } })
coll.attachSchema(MySchema)
export coll
```

My testing is currently done manually by git cloning my branch into a new Meteor v3 project. I've played around with Collection declarations & the `check` function.

Edit: I **haven't used `ValidatedMethod`** so I'm not sure if there's a risk of breakage.

![Screenshot 2025-01-03 at 3 37 52 am](https://github.com/user-attachments/assets/11e53144-f3d0-4ecf-bd07-20fd4e9cb45c)

Happy for any feedback or to follow any additional steps - this is my first time contributing to a Meteor package I think.